### PR TITLE
Add exact-value for total/avg days/months

### DIFF
--- a/endpoints/get-response-example.xml
+++ b/endpoints/get-response-example.xml
@@ -72,7 +72,7 @@
                     <cefr-level>B1</cefr-level>
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
-                <avg-months>5</avg-months>
+                <avg-months exact-value="5.25">5</avg-months>
                 <!-- At least one eqf-level is required for "mobility for studies". -->
                 <eqf-level>7</eqf-level>
                 <eqf-level>8</eqf-level>
@@ -96,7 +96,7 @@
                     <cefr-level>B1</cefr-level>
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
-                <total-months>70</total-months>
+                <total-months exact-value="70.00">70</total-months>
                 <!-- No eqf-level for traineeships. -->
             </student-traineeship-mobility-spec>
 
@@ -114,7 +114,7 @@
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
                 <!-- Staff mobilities have days instead of months. -->
-                <avg-days>14</avg-days>
+                <avg-days exact-value="13.5">14</avg-days>
             </staff-teacher-mobility-spec>
             <staff-teacher-mobility-spec>
                 <!-- Every specification describes a unidirectional mobility. If students or
@@ -131,7 +131,7 @@
                     <cefr-level>C1</cefr-level>
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
-                <avg-days>14</avg-days>
+                <avg-days>14</avg-days> <!-- exact-value is optional -->
             </staff-teacher-mobility-spec>
 
             <!-- Staff mobility for training. -->
@@ -147,7 +147,7 @@
                     <cefr-level>B2</cefr-level>
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
-                <total-days>28</total-days>
+                <total-days exact-value="28">28</total-days>
             </staff-training-mobility-spec>
         </cooperation-conditions>
     </iia>

--- a/endpoints/get-response.xsd
+++ b/endpoints/get-response.xsd
@@ -455,6 +455,47 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="BackwardCompatibleDecimal">
+        <xs:annotation>
+            <xs:documentation>
+                This type was introduced as a backward-compatible replacement for the
+                xs:positiveInteger type. We wanted to upgrade this type to a decimal with two
+                fractional digits, but we couldn't simply change this existing type without
+                breaking the older clients. Hence, we added an optional attribute with the
+                "upgraded" value. See this thread:
+
+                https://github.com/erasmus-without-paper/ewp-specs-api-iias/issues/23
+
+                Servers which keep the value in integer fields, are not required to use the
+                `exact-value` attribute. Servers which keep the value in decimal fields,
+                SHOULD use the `exact-value` attribute, and MUST provide a rounded integer
+                value in the element's content (for older clients which do not recognize the
+                `exact-value` attribute yet).
+
+                Clients should check if `exact-value` attribute is set. If it is, then take the
+                value from there. If it doesn't, then use the integer value from inside the
+                element.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:positiveInteger">
+                <xs:attribute use="optional" name="exact-value">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If given, then it overrides the integer value provided in the element's
+                            content. Please read the specs for the BackwardCompatibleDecimal type.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:decimal">
+                            <xs:fractionDigits value="2"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
     <xs:complexType name="StudentMobilitySpecification" abstract="true">
         <xs:annotation>
             <xs:documentation>
@@ -477,7 +518,7 @@
                                 https://github.com/erasmus-without-paper/ewp-specs-api-iias/issues/17
                             </xs:documentation>
                         </xs:annotation>
-                        <xs:element name="avg-months" type="xs:positiveInteger">
+                        <xs:element name="avg-months" type="BackwardCompatibleDecimal">
                             <xs:annotation>
                                 <xs:documentation>
                                     Average number of mobility months, per each academic year bound to the mobility
@@ -485,7 +526,7 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>
-                        <xs:element name="total-months" type="xs:positiveInteger">
+                        <xs:element name="total-months" type="BackwardCompatibleDecimal">
                             <xs:annotation>
                                 <xs:documentation>
                                     Total number of mobility months, for all academic years bound to the mobility
@@ -515,7 +556,7 @@
                                 `total-months` elements - please read the notes there too.
                             </xs:documentation>
                         </xs:annotation>
-                        <xs:element name="avg-days" type="xs:positiveInteger">
+                        <xs:element name="avg-days" type="BackwardCompatibleDecimal">
                             <xs:annotation>
                                 <xs:documentation>
                                     Average number of mobility days, per each academic year bound to the mobility
@@ -523,7 +564,7 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>
-                        <xs:element name="total-days" type="xs:positiveInteger">
+                        <xs:element name="total-days" type="BackwardCompatibleDecimal">
                             <xs:annotation>
                                 <xs:documentation>
                                     Total number of mobility days, for all academic years bound to the mobility

--- a/endpoints/get-response.xsd
+++ b/endpoints/get-response.xsd
@@ -466,15 +466,21 @@
 
                 https://github.com/erasmus-without-paper/ewp-specs-api-iias/issues/23
 
-                Servers which keep the value in integer fields, are not required to use the
-                `exact-value` attribute. Servers which keep the value in decimal fields,
-                SHOULD use the `exact-value` attribute, and MUST provide a rounded integer
-                value in the element's content (for older clients which do not recognize the
-                `exact-value` attribute yet).
+                * Servers which keep the value in integer fields, SHOULD NOT provide the
+                  `exact-value` attribute.
 
-                Clients should check if `exact-value` attribute is set. If it is, then take the
-                value from there. If it doesn't, then use the integer value from inside the
-                element.
+                * Servers which keep the value in decimal fields:
+
+                  - SHOULD provide the `exact-value` attribute in cases when the fractional
+                    part is non-zero.
+                  - MAY provide the `exact-value` attribute even when the fractional part is
+                    zero.
+                  - MUST provide the "legacy" rounded integer value in the element's content
+                    (for older clients which do not recognize the `exact-value` attribute yet).
+
+                * Clients SHOULD check if `exact-value` attribute is set. If it is, then take
+                  the value from there. If it isn't, then use the integer value from inside
+                  the element.
             </xs:documentation>
         </xs:annotation>
         <xs:simpleContent>


### PR DESCRIPTION
This is a proposed fix for issue:
https://github.com/erasmus-without-paper/ewp-specs-api-iias/issues/23
(based on Solution 1 described in this thread)