### PR TITLE
Decimals in total/avg days/months (backward-incompatible!)

### DIFF
--- a/endpoints/get-response-example.xml
+++ b/endpoints/get-response-example.xml
@@ -72,7 +72,7 @@
                     <cefr-level>B1</cefr-level>
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
-                <avg-months>5</avg-months>
+                <avg-months>5.25</avg-months>
                 <!-- At least one eqf-level is required for "mobility for studies". -->
                 <eqf-level>7</eqf-level>
                 <eqf-level>8</eqf-level>
@@ -96,7 +96,7 @@
                     <cefr-level>B1</cefr-level>
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
-                <total-months>70</total-months>
+                <total-months>70.00</total-months>
                 <!-- No eqf-level for traineeships. -->
             </student-traineeship-mobility-spec>
 
@@ -114,7 +114,7 @@
                 </recommended-language-skill>
                 <isced-f-code>0314</isced-f-code>
                 <!-- Staff mobilities have days instead of months. -->
-                <avg-days>14</avg-days>
+                <avg-days>13.5</avg-days>
             </staff-teacher-mobility-spec>
             <staff-teacher-mobility-spec>
                 <!-- Every specification describes a unidirectional mobility. If students or

--- a/endpoints/get-response.xsd
+++ b/endpoints/get-response.xsd
@@ -477,21 +477,33 @@
                                 https://github.com/erasmus-without-paper/ewp-specs-api-iias/issues/17
                             </xs:documentation>
                         </xs:annotation>
-                        <xs:element name="avg-months" type="xs:positiveInteger">
+                        <xs:element name="avg-months">
                             <xs:annotation>
                                 <xs:documentation>
                                     Average number of mobility months, per each academic year bound to the mobility
                                     specification.
                                 </xs:documentation>
                             </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:decimal">
+                                    <xs:minExclusive value="0"/>
+                                    <xs:fractionDigits value="2"/>
+                                </xs:restriction>
+                            </xs:simpleType>
                         </xs:element>
-                        <xs:element name="total-months" type="xs:positiveInteger">
+                        <xs:element name="total-months">
                             <xs:annotation>
                                 <xs:documentation>
                                     Total number of mobility months, for all academic years bound to the mobility
                                     specification.
                                 </xs:documentation>
                             </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:decimal">
+                                    <xs:minExclusive value="0"/>
+                                    <xs:fractionDigits value="2"/>
+                                </xs:restriction>
+                            </xs:simpleType>
                         </xs:element>
                     </xs:choice>
                 </xs:sequence>
@@ -515,21 +527,33 @@
                                 `total-months` elements - please read the notes there too.
                             </xs:documentation>
                         </xs:annotation>
-                        <xs:element name="avg-days" type="xs:positiveInteger">
+                        <xs:element name="avg-days">
                             <xs:annotation>
                                 <xs:documentation>
                                     Average number of mobility days, per each academic year bound to the mobility
                                     specification.
                                 </xs:documentation>
                             </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:decimal">
+                                    <xs:minExclusive value="0"/>
+                                    <xs:fractionDigits value="2"/>
+                                </xs:restriction>
+                            </xs:simpleType>
                         </xs:element>
-                        <xs:element name="total-days" type="xs:positiveInteger">
+                        <xs:element name="total-days">
                             <xs:annotation>
                                 <xs:documentation>
                                     Total number of mobility days, for all academic years bound to the mobility
                                     specification.
                                 </xs:documentation>
                             </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:decimal">
+                                    <xs:minExclusive value="0"/>
+                                    <xs:fractionDigits value="2"/>
+                                </xs:restriction>
+                            </xs:simpleType>
                         </xs:element>
                     </xs:choice>
                 </xs:sequence>


### PR DESCRIPTION
This is a proposed fix for issue:
https://github.com/erasmus-without-paper/ewp-specs-api-iias/issues/23
(based on Solution 2 described in this thread)